### PR TITLE
Coerce bass and treble input in range

### DIFF
--- a/soco.py
+++ b/soco.py
@@ -376,6 +376,7 @@ class SoCo(object):
 
         """
         if bass is not False:
+            bass = max(-10, min(bass, 10))  # Coerce in range
             body = SET_BASS_BODY_TEMPLATE.format(bass=bass)
 
             response = self.__send_command(RENDERING_ENDPOINT, SET_BASS_ACTION, body)
@@ -411,6 +412,7 @@ class SoCo(object):
 
         """
         if treble is not False:
+            treble = max(-10, min(treble, 10))  # Coerce in range
             body = SET_TREBLE_BODY_TEMPLATE.format(treble=treble)
 
             response = self.__send_command(RENDERING_ENDPOINT, SET_TREBLE_ACTION, body)


### PR DESCRIPTION
While writing some unit tests I noticed that the sonos units reacts differently to input that is out of range. When adjusting the volume it will give an error, but when adjusting treble and bass it will coerce the value in range, so asking for bass(20) wil simply give you bass(10) which is the maximum value. However, once, while I was writing the unit tests and asked for bass(1000) the sonos unit produced a very loud and equipment unhealthy sounding noise, so I suggest that we adjust the values to within range in case the user asks for something invalid.
