### PR TITLE
Various text encoding fixes

### DIFF
--- a/soco.py
+++ b/soco.py
@@ -580,9 +580,9 @@ class SoCo(object):
         """
         response = self.__send_command(TRANSPORT_ENDPOINT, GET_CUR_TRACK_ACTION, GET_CUR_TRACK_BODY)
 
-        dom = XML.fromstring(response)
+        dom = XML.fromstring(response.encode('utf-8'))
 
-        track = {}
+        track = {'title': '', 'artist': '', 'album': '', 'album_art': ''}
 
         track['playlist_position'] = dom.findtext('.//Track')
         track['duration'] = dom.findtext('.//TrackDuration')
@@ -597,29 +597,24 @@ class SoCo(object):
             # #Try parse trackinfo
             trackinfo = metadata.findtext('.//{urn:schemas-rinconnetworks-com:metadata-1-0/}streamContent')
 
-            try:
-                index = trackinfo.find(' - ')
-
-                if index > -1:
-                    track['artist'] = trackinfo[:index]
-                    track['title'] = trackinfo[index+3:]
-            except:
+            index = trackinfo.find(' - ')
+            if index > -1:
+                track['artist'] = trackinfo[:index]
+                track['title'] = trackinfo[index+3:]
+            else:
                 logger.warning('Could not handle track info: "%s"', trackinfo)
                 logger.warning(traceback.format_exc())
-                track['artist'] = ''
-                track['title'] = trackinfo
+                track['title'] = trackinfo.encode('utf-8')
 
-            track['album'] = ''
-            track['album_art'] = ''
         # If the speaker is playing from the line-in source, querying for track
         # metadata will return "NOT_IMPLEMENTED".
         elif d != '' and d != 'NOT_IMPLEMENTED':
             # Track metadata is returned in DIDL-Lite format
             metadata = XML.fromstring(d.encode('utf-8'))
 
-            track['title'] = metadata.findtext('.//{http://purl.org/dc/elements/1.1/}title')
-            track['artist'] = metadata.findtext('.//{http://purl.org/dc/elements/1.1/}creator')
-            track['album'] = metadata.findtext('.//{urn:schemas-upnp-org:metadata-1-0/upnp/}album')
+            track['title'] = metadata.findtext('.//{http://purl.org/dc/elements/1.1/}title').encode('utf-8')
+            track['artist'] = metadata.findtext('.//{http://purl.org/dc/elements/1.1/}creator').encode('utf-8')
+            track['album'] = metadata.findtext('.//{urn:schemas-upnp-org:metadata-1-0/upnp/}album').encode('utf-8')
 
             album_art = metadata.findtext('.//{urn:schemas-upnp-org:metadata-1-0/upnp/}albumArtURI')
 
@@ -627,11 +622,7 @@ class SoCo(object):
                 track['album_art'] = 'http://' + self.speaker_ip + ':1400' + metadata.findtext('.//{urn:schemas-upnp-org:metadata-1-0/upnp/}albumArtURI')
             else:
                 track['album_art'] = ''
-        else:
-            track['title'] = ''
-            track['artist'] = ''
-            track['album'] = ''
-            track['album_art'] = ''
+
 
         return track
 
@@ -653,7 +644,7 @@ class SoCo(object):
 
             dom = XML.fromstring(response.content)
 
-            self.speaker_info['zone_name'] = dom.findtext('.//ZoneName')
+            self.speaker_info['zone_name'] = dom.findtext('.//ZoneName').encode('utf-8')
             self.speaker_info['zone_icon'] = dom.findtext('.//ZoneIcon')
             self.speaker_info['uid'] = dom.findtext('.//LocalUID')
             self.speaker_info['serial_number'] = dom.findtext('.//SerialNumber')
@@ -855,7 +846,7 @@ class SoCo(object):
             
         response = self.__send_command(CONTENT_DIRECTORY_ENDPOINT, BROWSE_ACTION, body)
 
-        dom = XML.fromstring(response)
+        dom = XML.fromstring(response.encode('utf-8'))
 
         result = {}
         favorites = []
@@ -869,7 +860,7 @@ class SoCo(object):
             for item in metadata.findall('.//{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}item'):
                 favorite = {}
 
-                favorite['title'] = item.findtext('.//{http://purl.org/dc/elements/1.1/}title')
+                favorite['title'] = item.findtext('.//{http://purl.org/dc/elements/1.1/}title').encode('utf-8')
                 favorite['uri'] = item.findtext('.//{urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/}res')
 
                 favorites.append(favorite)

--- a/soco.py
+++ b/soco.py
@@ -620,9 +620,6 @@ class SoCo(object):
 
             if album_art is not None:
                 track['album_art'] = 'http://' + self.speaker_ip + ':1400' + metadata.findtext('.//{urn:schemas-upnp-org:metadata-1-0/upnp/}albumArtURI')
-            else:
-                track['album_art'] = ''
-
 
         return track
 


### PR DESCRIPTION
I noticed some text encoding issues, because I live in a country with a few non-ascii characters. I noticed it while querying the zone names (Kitchen is spelled Køkken in Danish ;)) and then decided to have a look at the track info and favorite radio stations methods as well. I also included a few minor changes besides text encoding changes, described below:

get_speaker_info: Trivial fix to encode zone names as utf-8

get_current_track_info:
- I had to encode as utf-8 already before the first time the text is parsed as xml (line 583), otherwise I got an exception on music tracks with non-ascii letters.
- I moved the default values for 'title', 'artist' 'album' and 'album_art' up before the if-conditional. The reason for this is that those values were not always being filled in, depending on where in the large conditional you end up (described below). This way we are sure they are always there and we can remove all the default "something equals empty string" assignments in the conditional.
- I replaced the try-except at the .find(' - ') line 600 with a simple if-else. I wasn't able to make those statements produce an exception and actually if we don't produce an exception and we didn't find the string, then we never make the track['title'] = trackinfo assignment.

__get_radio_favorites: Trivial fix to encode names as utf-8
