### PR TITLE
Remove Speaker from Group / Metadata for URIs

### DIFF
--- a/examples/commandline/tunein.py
+++ b/examples/commandline/tunein.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import sys
+import time
+
+
+from soco import SoCo
+from soco import SonosDiscovery
+#from zone import SonosZone
+
+
+meta_template = '&lt;DIDL-Lite xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot; xmlns:upnp=&quot;urn:schemas-upnp-org:metadata-1-0/upnp/&quot; xmlns:r=&quot;urn:schemas-rinconnetworks-com:metadata-1-0/&quot; xmlns=&quot;urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/&quot;&gt;&lt;item id=&quot;R:0/0/0&quot; parentID=&quot;R:0/0&quot; restricted=&quot;true&quot;&gt;&lt;dc:title&gt;{title}&lt;/dc:title&gt;&lt;upnp:class&gt;object.item.audioItem.audioBroadcast&lt;/upnp:class&gt;&lt;desc id=&quot;cdudn&quot; nameSpace=&quot;urn:schemas-rinconnetworks-com:metadata-1-0/&quot;&gt;{service}&lt;/desc&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;'
+
+tunein_service = 'SA_RINCON65031_'
+
+if __name__ == '__main__':
+
+    if (len(sys.argv) > 1):
+      speaker_ip = sys.argv[1]
+
+    if (len(sys.argv) == 3):
+      preset = int(sys.argv[2]) - 1
+      limit = 1
+    else:
+      preset = 0
+      limit = 12
+
+    mySonos = SoCo(speaker_ip)
+
+    if mySonos:
+        stations = mySonos.get_favorite_radio_stations( preset, limit)
+        print 'returned %s of a possible %s radio stations:' % (stations['returned'], stations['total'])
+	for fave in stations['favorites']:    
+	    print fave['title']
+
+            uri = fave['uri']
+            # TODO seems at least & needs to be escaped - should move this to play_uri and maybe escape other chars.
+            uri = uri.replace('&', '&amp;')
+
+            metadata = meta_template.format(title='', service=tunein_service)
+
+            print mySonos.play_uri( uri, metadata)
+
+            if (len(sys.argv) == 2):
+               time.sleep( 10)
+
+
+

--- a/soco.py
+++ b/soco.py
@@ -71,6 +71,7 @@ class SoCo(object):
     get_speaker_info -- Get information about the Sonos speaker.
     partymode -- Put all the speakers in the network in the same group.
     join -- Join this speaker to another "master" speaker.
+    unjoin -- Remove this speaker from a group.
     get_speaker_info -- Get information on this speaker.
     get_queue -- Get information about the queue.
     add_to_queue -- Add a track to the end of the queue
@@ -511,6 +512,23 @@ class SoCo(object):
         response = self.__send_command(TRANSPORT_ENDPOINT, SET_TRANSPORT_ACTION, body)
 
         if (response == JOIN_RESPONSE):
+            return True
+        else:
+            return self.__parse_error(response)
+
+    def unjoin(self):
+        """ Remove this speaker from a group.
+
+        Seems to work ok even if you remove what was previously the group master from it's own group.
+        If the speaker was not in a group also returns ok.
+
+		Returns:
+		True if this speaker has left the group'
+        """
+
+        response = self.__send_command(TRANSPORT_ENDPOINT, UNJOIN_ACTION, UNJOIN_BODY)
+        
+        if (response == UNJOIN_RESPONSE):
             return True
         else:
             return self.__parse_error(response)
@@ -995,6 +1013,10 @@ SET_TRANSPORT_ACTION = '"urn:schemas-upnp-org:service:AVTransport:1#SetAVTranspo
 
 JOIN_BODY_TEMPLATE = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>x-rincon:{master_uid}</CurrentURI><CurrentURIMetaData></CurrentURIMetaData></u:SetAVTransportURI>'
 JOIN_RESPONSE = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetAVTransportURIResponse xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"></u:SetAVTransportURIResponse></s:Body></s:Envelope>'
+
+UNJOIN_ACTION = '"urn:schemas-upnp-org:service:AVTransport:1#BecomeCoordinatorOfStandaloneGroup"'
+UNJOIN_BODY = '<u:BecomeCoordinatorOfStandaloneGroup xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:BecomeCoordinatorOfStandaloneGroup>'
+UNJOIN_RESPONSE = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:BecomeCoordinatorOfStandaloneGroupResponse xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"></u:BecomeCoordinatorOfStandaloneGroupResponse></s:Body></s:Envelope>'
 
 SET_LINEIN_BODY_TEMPLATE = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>x-rincon-stream:{speaker_uid}</CurrentURI><CurrentURIMetaData></CurrentURIMetaData></u:SetAVTransportURI>'
 SET_LINEIN_RESPONSE = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetAVTransportURIResponse xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"></u:SetAVTransportURIResponse></s:Body></s:Envelope>'

--- a/soco.py
+++ b/soco.py
@@ -170,7 +170,7 @@ class SoCo(object):
             return self.__parse_error(response)
 
 
-    def play_uri(self, uri=''):
+    def play_uri(self, uri='', meta=''):
         """Play a given stream. Pauses the queue.
 
         Arguments:
@@ -184,7 +184,8 @@ class SoCo(object):
         speaker will be returned.
 
         """
-        body = PLAY_URI_BODY_TEMPLATE.format(uri=uri)
+
+        body = PLAY_URI_BODY_TEMPLATE.format(uri=uri,meta=meta)
 
         response = self.__send_command(TRANSPORT_ENDPOINT, SET_TRANSPORT_ACTION, body)
 
@@ -864,7 +865,7 @@ class SoCo(object):
         body = GET_RADIO_FAVORITES_BODY_TEMPLATE.format(favorite_type, start, max_items)
             
         response = self.__send_command(CONTENT_DIRECTORY_ENDPOINT, BROWSE_ACTION, body)
-
+        
         dom = XML.fromstring(response.encode('utf-8'))
 
         result = {}
@@ -1041,7 +1042,7 @@ SEEK_TRACK_BODY_TEMPLATE = '''
 
 SEEK_TIMESTAMP_BODY_TEMPLATE = '<u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Unit>REL_TIME</Unit><Target>{timestamp}</Target></u:Seek>'
 
-PLAY_URI_BODY_TEMPLATE = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>{uri}</CurrentURI><CurrentURIMetaData></CurrentURIMetaData></u:SetAVTransportURI>'
+PLAY_URI_BODY_TEMPLATE = '<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>{uri}</CurrentURI><CurrentURIMetaData>{meta}</CurrentURIMetaData></u:SetAVTransportURI>'
 
 GET_QUEUE_BODY_TEMPLATE = '<u:Browse xmlns:u="urn:schemas-upnp-org:service:ContentDirectory:1#Browse"><ObjectID>Q:0</ObjectID><BrowseFlag>BrowseDirectChildren</BrowseFlag><Filter>dc:title,res,dc:creator,upnp:artist,upnp:album,upnp:albumArtURI</Filter><StartingIndex>{0}</StartingIndex><RequestedCount>{1}</RequestedCount><SortCriteria></SortCriteria></u:Browse>'
 


### PR DESCRIPTION
Minor new function allows speakers to be un-grouped.
Tested with a 4 speaker network. No apparent problems with removing group masters or ungrouped speakers, the topology updates appear to correctly notify other controllers of the changes and they respond appropriately. There may be extra work to do to re-start playback on an orphaned group after removing master.

Added parameter to play_url to allow meta data to be set - this needed to allow the speakers to connect up to services (e.g. Tunein) to allow streams hosted by those services to play. Most useful in this context to play back the Favourite Radio stations discovered by get_favorite_radio_stations.

First commit ever using GIT so be gentle and I hope I have done it right.
